### PR TITLE
Fix type error in nonce repr format string

### DIFF
--- a/Lib/pyhsm/basic_cmd.py
+++ b/Lib/pyhsm/basic_cmd.py
@@ -250,10 +250,10 @@ class YHSM_NonceResponse():
         self.nonce = nonce
 
     def __repr__(self):
-        return '<%s instance at %s: nonce=%i, pu_count=%i, volatile=%i>' % (
+        return '<%s instance at %s: nonce=%s, pu_count=%i, volatile=%i>' % (
             self.__class__.__name__,
             hex(id(self)),
-            self.nonce,
+            self.nonce.encode('hex'),
             self.pu_count,
             self.volatile
             )


### PR DESCRIPTION
Before patch:

> > > import pyhsm
> > > hsm=pyhsm.YHSM(device='/dev/ttyACM0')
> > > hsm.get_nonce()
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > >   File "/usr/local/lib/python2.6/dist-packages/pyhsm-0.9.8c-py2.6.egg/pyhsm/basic_cmd.py", line 258, in **repr**
> > >     self.volatile
> > > TypeError: %d format: a number is required, not str

After patch:

> > > import pyhsm
> > > hsm=pyhsm.YHSM(device='/dev/ttyACM0')
> > > hsm.get_nonce()
> > > <YHSM_NonceResponse instance at 0x7f06008ef368: nonce=050000002700, pu_count=39, volatile=5>
