### PR TITLE
SoftHSM: emulate the hardware and generate a random nonce when none is set

### DIFF
--- a/pyhsm/soft_hsm.py
+++ b/pyhsm/soft_hsm.py
@@ -208,6 +208,9 @@ class SoftYHSM(object):
         self._buffer = self._buffer[:offset] + os.urandom(num_bytes)
 
     def generate_aead(self, nonce, key_handle):
+        if nonce == "":
+            # no hardware to generate it for us, so do it here.
+            nonce = os.urandom(6)
         aes_key = self._get_key(key_handle, pyhsm.defines.YSM_BUFFER_AEAD_GENERATE)
         ct = pyhsm.soft_hsm.aesCCM(aes_key, key_handle, nonce, self._buffer,
                                    False)


### PR DESCRIPTION
Tested like this:

```
$ yhsm-generate-keys --key-handles 1 --start-public-id dj0000cccccc  -O ./apa2 --count 1000 -D ./secrets.json  --random-nonce

$ yhsm-decrypt-aead --aes-key 0000000100020003000400050006000700080009000a000b000c000d000e000f --key-handle 1 --format yubikey-csv apa2 | tail -1
1000,djcccccccecn,8859623f45d4,9a37bf9ab73a75435133a7d290009276,000000000000,,,,,,

# start server
$ yhsm-yubikey-ksm -D ./secrets.json --key-handle 1 -B apa2

# program otp slot on a yubikey with key 1000 from above
$ ../yubikey-personalization/ykpersonalize -1 -ofixed=djcccccccecn  -ouid=8859623f45d4 -a9a37bf9ab73a75435133a7d290009276
Firmware version 4.3.7 Touch level 519 Program sequence 4

Configuration data to be written to key configuration 1:

fixed: m:djcccccccecn
uid: 8859623f45d4
key: h:9a37bf9ab73a75435133a7d290009276
acc_code: h:000000000000
ticket_flags: APPEND_CR
config_flags:
extended_flags:

Commit? (y/n) [n]: y
$

# validate:
$ curl http://localhost:8002/wsapi/decrypt?otp=djcccccccecngrfnckfhccbunvevhfvheljuujnfeegv
OK counter=0001 low=4a54 high=13 use=00
$ curl http://localhost:8002/wsapi/decrypt?otp=djcccccccecnhubcdvknrgcnjteidtfhchfgvrfrlitk
OK counter=0001 low=4a8c high=13 use=01
```
