### PR TITLE
Connection close by mysql/mariadb

### DIFF
--- a/pyhsm/ksm/yubikey_ksm.py
+++ b/pyhsm/ksm/yubikey_ksm.py
@@ -207,7 +207,7 @@ class FSBackend(object):
 
 class SQLBackend(object):
     def __init__(self, db_url, key_handles):
-        self.engine = sqlalchemy.create_engine(db_url)
+        self.engine = sqlalchemy.create_engine(db_url, pool_pre_ping=True)
         metadata = sqlalchemy.MetaData()
         self.aead_table = sqlalchemy.Table('aead_table', metadata, autoload=True, autoload_with=self.engine)
         self.key_handles = key_handles


### PR DESCRIPTION
After sleep time mysql close the connection but sqlalchemy still have connection open.

That cause exception raise at line 234

pool_pre_ping=True test if the connection need to be restart. https://docs.sqlalchemy.org/en/14/core/pooling.html

https://github.com/Yubico/python-pyhsm/issues/22