### PR TITLE
Python-pyhsm conversion to work with python3

### DIFF
--- a/pyhsm/__init__.py
+++ b/pyhsm/__init__.py
@@ -41,7 +41,7 @@ Basic usage ::
 See help(pyhsm.base) (L{pyhsm.base.YHSM}) for more information.
 """
 
-__version__ = '1.2.2-dev0'
+__version__ = '1.2.2'
 __copyright__ = 'Yubico AB'
 __organization__ = 'Yubico'
 __license__ = 'BSD'

--- a/pyhsm/aead_cmd.py
+++ b/pyhsm/aead_cmd.py
@@ -45,7 +45,7 @@ class YHSM_AEAD_Cmd(YHSM_Cmd):
             return '<%s instance at %s: nonce=%s, key_handle=0x%x, status=%s>' % (
                 self.__class__.__name__,
                 hex(id(self)),
-                self.nonce.encode('hex'),
+                self.nonce,
                 self.key_handle,
                 pyhsm.defines.status2str(self.status)
                 )
@@ -200,9 +200,9 @@ class YHSM_GeneratedAEAD():
         self.data = aead
 
     def __repr__(self):
-        nonce_str = "None"
+        nonce_str = b"None"
         if self.nonce is not None:
-            nonce_str = self.nonce.encode('hex')
+            nonce_str = self.nonce
         return '<%s instance at %s: nonce=%s, key_handle=0x%x, data=%i bytes>' % (
             self.__class__.__name__,
             hex(id(self)),
@@ -262,4 +262,4 @@ class YHSM_YubiKeySecret():
         #   uint8_t key[KEY_SIZE];              // AES key
         #   uint8_t uid[UID_SIZE];              // Unique (secret) ID
         # } YUBIKEY_SECRETS;
-        return self.key + self.uid.ljust(pyhsm.defines.UID_SIZE, chr(0))
+        return self.key + self.uid.ljust(pyhsm.defines.UID_SIZE, b'\x00')

--- a/pyhsm/aes_ecb_cmd.py
+++ b/pyhsm/aes_ecb_cmd.py
@@ -78,7 +78,7 @@ class YHSM_Cmd_AES_ECB_Encrypt(YHSM_Cmd_AES_ECB):
         #   uint8_t plaintext[YHSM_BLOCK_SIZE];  // Plaintext block
         # } YHSM_ECB_BLOCK_ENCRYPT_REQ;
         payload = struct.pack('<I', key_handle) + \
-            plaintext.ljust(pyhsm.defines.YSM_BLOCK_SIZE, chr(0x0))
+            plaintext.ljust(pyhsm.defines.YSM_BLOCK_SIZE, b'\x00')
         YHSM_Cmd_AES_ECB.__init__(self, stick, pyhsm.defines.YSM_AES_ECB_BLOCK_ENCRYPT, payload)
 
 

--- a/pyhsm/base.py
+++ b/pyhsm/base.py
@@ -101,7 +101,7 @@ class YHSM():
         pyhsm.cmd.reset(self.stick)
         if test_sync:
             # Now verify we are in sync
-            data = 'ekoeko'
+            data = b'ekoeko'
             echo = self.echo(data)
             # XXX analyze 'echo' to see if we are in config mode, and produce a
             # nice exception if we are.
@@ -134,18 +134,18 @@ class YHSM():
         In some scenarios, communications with the YubiHSM might be affected
         by terminal line settings turning CR into LF for example.
         """
-        data = ''.join([chr(x) for x in range(256)])
-        data = data + '0d0a0d0a'.decode('hex')
+        data = bytes(range(256))
+        data+= bytes.fromhex('0d0a0d0a')
         chunk_size = pyhsm.defines.YSM_MAX_PKT_SIZE - 10 # max size of echo
         count = 0
         while data:
             this = data[:chunk_size]
             data = data[chunk_size:]
             res = self.echo(this)
-            for i in xrange(len(this)):
+            for i in range(len(this)):
                 if res[i] != this[i]:
                     msg = "Echo test failed at position %i (0x%x != 0x%x)" \
-                        % (count + i, ord(res[i]), ord(this[i]))
+                        % (count + i, res[i], this[i])
                     raise pyhsm.exception.YHSM_Error(msg)
             count += len(this)
 
@@ -276,8 +276,8 @@ class YHSM():
             res = True
         if res and otp is not None:
             (public_id, otp,) = pyhsm.yubikey.split_id_otp(otp)
-            public_id = pyhsm.yubikey.modhex_decode(public_id).decode('hex')
-            otp = pyhsm.yubikey.modhex_decode(otp).decode('hex')
+            public_id = pyhsm.yubikey.modhex_decode(public_id)
+            otp = pyhsm.yubikey.modhex_decode(otp)
             return pyhsm.basic_cmd.YHSM_Cmd_HSM_Unlock(self.stick, public_id, otp).execute()
         return res
 
@@ -452,13 +452,13 @@ class YHSM():
 
         @see: L{pyhsm.validate_cmd.YHSM_Cmd_AEAD_Validate_OTP}
         """
-        if type(public_id) is not str:
+        if type(public_id) is not bytes:
             assert()
-        if type(otp) is not str:
+        if type(otp) is not bytes:
             assert()
         if type(key_handle) is not int:
             assert()
-        if type(aead) is not str:
+        if type(aead) is not bytes:
             assert()
         return pyhsm.validate_cmd.YHSM_Cmd_AEAD_Validate_OTP( \
             self.stick, public_id, otp, key_handle, aead).execute()

--- a/pyhsm/basic_cmd.py
+++ b/pyhsm/basic_cmd.py
@@ -32,13 +32,13 @@ class YHSM_Cmd_Echo(YHSM_Cmd):
     """
     Send something to the stick, and expect to get it echoed back.
     """
-    def __init__(self, stick, payload=''):
+    def __init__(self, stick, payload=b''):
         payload = pyhsm.util.input_validate_str(payload, 'payload', max_len = pyhsm.defines.YSM_MAX_PKT_SIZE - 1)
         # typedef struct {
         #   uint8_t numBytes;                   // Number of bytes in data field
         #   uint8_t data[YSM_MAX_PKT_SIZE - 1]; // Data
         # } YSM_ECHO_REQ;
-        packed = chr(len(payload)) + payload
+        packed = bytes([len(payload)]) + payload
         YHSM_Cmd.__init__(self, stick, pyhsm.defines.YSM_ECHO, packed)
 
     def parse_result(self, data):
@@ -77,7 +77,7 @@ class YHSM_Cmd_System_Info(YHSM_Cmd):
                 hex(id(self)),
                 (self.version_major, self.version_minor, self.version_build),
                 self.protocol_ver,
-                self.system_uid.encode('hex')
+                self.system_uid
                 )
         else:
             return '<%s instance at %s (not executed)>' % (
@@ -119,7 +119,7 @@ class YHSM_Cmd_Random(YHSM_Cmd):
         #   uint8_t numBytes;                   // Number of bytes generated
         #   uint8_t rnd[YSM_MAX_PKT_SIZE - 1];  // Random data
         # } YHSM_RANDOM_GENERATE_RESP;
-        num_bytes = pyhsm.util.validate_cmd_response_int('num_bytes', ord(data[0]), self.num_bytes)
+        num_bytes = pyhsm.util.validate_cmd_response_int('num_bytes', data[0], self.num_bytes)
         return data[1:1 + num_bytes]
 
 
@@ -256,7 +256,7 @@ class YHSM_Cmd_Key_Storage_Unlock(YHSM_Cmd):
         # typedef struct {
         #   uint8_t password[YSM_BLOCK_SIZE];  // Unlock password
         # } YSM_KEY_STORAGE_UNLOCK_REQ;
-        packed = payload.ljust(pyhsm.defines.YSM_BLOCK_SIZE, chr(0x0))
+        packed = payload.ljust(pyhsm.defines.YSM_BLOCK_SIZE, b'\x00')
         YHSM_Cmd.__init__(self, stick, pyhsm.defines.YSM_KEY_STORAGE_UNLOCK, packed)
 
     def parse_result(self, data):
@@ -297,7 +297,7 @@ class YHSM_Cmd_Key_Store_Decrypt(YHSM_Cmd):
         # typedef struct {
         #   uint8_t key[YSM_MAX_KEY_SIZE];      // Key store decryption key
         # } YSM_KEY_STORE_DECRYPT_REQ;
-        packed = payload.ljust(pyhsm.defines.YSM_MAX_KEY_SIZE, chr(0x0))
+        packed = payload.ljust(pyhsm.defines.YSM_MAX_KEY_SIZE, b'\x00')
         YHSM_Cmd.__init__(self, stick, pyhsm.defines.YSM_KEY_STORE_DECRYPT, packed)
 
     def parse_result(self, data):
@@ -397,7 +397,7 @@ class YHSM_NonceResponse():
         return '<%s instance at %s: nonce=%s, pu_count=%i, volatile=%i>' % (
             self.__class__.__name__,
             hex(id(self)),
-            self.nonce.encode('hex'),
+            self.nonce,
             self.pu_count,
             self.volatile
             )

--- a/pyhsm/buffer_cmd.py
+++ b/pyhsm/buffer_cmd.py
@@ -58,7 +58,7 @@ class YHSM_Cmd_Buffer_Load(YHSM_Cmd):
         # typedef struct {
         #   uint8_t numBytes;                   // Number of bytes in buffer now
         # } YSM_BUFFER_LOAD_RESP;
-        count = ord(data[0])
+        count = data[0]
         if self.offset == 0:
             # if offset was 0, the buffer was reset and
             # we can verify the length returned
@@ -90,7 +90,7 @@ class YHSM_Cmd_Buffer_Random_Load(YHSM_Cmd):
         # typedef struct {
         #   uint8_t numBytes;                   // Number of bytes in buffer now
         # } YSM_BUFFER_LOAD_RESP;
-        count = ord(data[0])
+        count = data[0]
         if self.offset == 0:
             # if offset was 0, the buffer was reset and
             # we can verify the length returned

--- a/pyhsm/cmd.py
+++ b/pyhsm/cmd.py
@@ -62,6 +62,8 @@ class YHSM_Cmd():
             cmd_buf = struct.pack('BB', len(self.payload) + 1, self.command)
         else:
             cmd_buf = bytes([self.command])
+        if not isinstance(self.payload, (bytes, bytearray)):
+            self.payload = self.payload.encode()
         cmd_buf += self.payload
         debug_info = None
         unlock = self.stick.acquire()

--- a/pyhsm/cmd.py
+++ b/pyhsm/cmd.py
@@ -61,7 +61,7 @@ class YHSM_Cmd():
             # YSM_NULL is the exception to the rule - it should NOT be prefixed with YSM_PKT.bcnt
             cmd_buf = struct.pack('BB', len(self.payload) + 1, self.command)
         else:
-            cmd_buf = chr(self.command)
+            cmd_buf = bytes([self.command])
         cmd_buf += self.payload
         debug_info = None
         unlock = self.stick.acquire()
@@ -127,16 +127,16 @@ class YHSM_Cmd():
         if not res:
             reset(self.stick)
             raise pyhsm.exception.YHSM_Error('YubiHSM did not respond to command %s' \
-                                                 % (pyhsm.defines.cmd2str(self.command)) )
+                                                 % (pyhsm.defines.cmd2str(self.command)))
         # try to check if it is a YubiHSM in configuration mode
-        self.stick.write('\r\r\r', '(mode test)')
-        res2 = self.stick.read(50) # expect a timeout
+        self.stick.write(b'\r\r\r', '(mode test)')
+        res2 = self.stick.read(50).decode() # expect a timeout
         lines = res2.split('\n')
         for this in lines:
             if re.match('^(NO_CFG|WSAPI|HSM).*> .*', this):
                 raise pyhsm.exception.YHSM_Error('YubiHSM is in configuration mode')
-        raise pyhsm.exception.YHSM_Error('Unknown response from serial device %s : "%s"' \
-                                             % (self.stick.device, res.encode('hex')))
+        raise pyhsm.exception.YHSM_Error('Unknown response from serial device %s, %s : "%s"' \
+                                             % (self.stick.device, res, len(res.encode())))
 
     def parse_result(self, data):
         """

--- a/pyhsm/cmd.py
+++ b/pyhsm/cmd.py
@@ -137,8 +137,8 @@ class YHSM_Cmd():
         for this in lines:
             if re.match('^(NO_CFG|WSAPI|HSM).*> .*', this):
                 raise pyhsm.exception.YHSM_Error('YubiHSM is in configuration mode')
-        raise pyhsm.exception.YHSM_Error('Unknown response from serial device %s, %s : "%s"' \
-                                             % (self.stick.device, res, len(res.encode())))
+        raise pyhsm.exception.YHSM_Error('Unknown response from serial device %s : "%s"' \
+                                             % (self.stick.device, res()))
 
     def parse_result(self, data):
         """

--- a/pyhsm/db_cmd.py
+++ b/pyhsm/db_cmd.py
@@ -105,7 +105,7 @@ class YHSM_Cmd_DB_Validate_OTP(YHSM_Cmd):
             return '<%s instance at %s: public_id=%s, status=0x%x>' % (
                 self.__class__.__name__,
                 hex(id(self)),
-                self.public_id.encode('hex'),
+                bytes.fromhex(self.public_id),
                 self.status
                 )
         else:

--- a/pyhsm/hmac_cmd.py
+++ b/pyhsm/hmac_cmd.py
@@ -133,6 +133,8 @@ class YHSM_GeneratedHMACSHA1():
             self.__class__.__name__,
             hex(id(self)),
             self.key_handle,
-            self.hash_result[:4].encode('hex'),
+            self.hash_result[:4],
             self.final,
             )
+
+

--- a/pyhsm/ksm/db_export.py
+++ b/pyhsm/ksm/db_export.py
@@ -18,7 +18,7 @@ import pyhsm.aead_cmd
 
 def insert_slash(string, every=2):
     """insert_slash insert / every 2 char"""
-    return os.path.join(string[i:i+every] for i in xrange(0, len(string), every))
+    return os.path.join(string[i:i+every] for i in range(0, len(string), every))
 
 
 def mkdir_p(path):

--- a/pyhsm/ksm/db_import.py
+++ b/pyhsm/ksm/db_import.py
@@ -97,7 +97,7 @@ def main():
                 aead.key_handle = key_handle_to_int(keyhandle)
 
             if not insert_query(connection, public_id, aead, keyhandle, aeadobj):
-                print("WARNING: could not insert %s" % public_id)
+                print(("WARNING: could not insert %s" % public_id))
 
     #close sqlalchemy
     connection.close()

--- a/pyhsm/ksm/yubikey_ksm.py
+++ b/pyhsm/ksm/yubikey_ksm.py
@@ -102,14 +102,14 @@ class YHSM_KSMRequestHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header('Content-type', 'text/html')
             self.end_headers()
-            self.wfile.write(val_res)
-            self.wfile.write("\n")
+            self.wfile.write(bytes(val_res, 'utf-8'))
+            self.wfile.write(bytes("\n", 'utf-8'))
         elif self.stats_url and self.path == self.stats_url:
             self.send_response(200)
             self.send_header('Content-type', 'text/html')
             self.end_headers()
             for key in stats:
-                self.wfile.write("%s %d\n" % (key, stats[key]))
+                self.wfile.write(bytes("%s %d\n" % (key, stats[key]), 'utf-8'))
         else:
             self.log_error("Bad URL '%s' - I'm serving '%s' (responding 403)" % (self.path, self.serve_url))
             self.send_response(403, 'Forbidden')

--- a/pyhsm/oath_hotp.py
+++ b/pyhsm/oath_hotp.py
@@ -34,7 +34,7 @@ def search_for_oath_code(hsm, key_handle, nonce, aead, counter, user_code, look_
     hsm.load_temp_key(nonce, key_handle, aead)
     # User might have produced codes never sent to us, so we support trying look_ahead
     # codes to see if we find the user's current code.
-    for j in xrange(look_ahead):
+    for j in range(look_ahead):
         this_counter = counter + j
         secret = struct.pack("> Q", this_counter)
         hmac_result = hsm.hmac_sha1(pyhsm.defines.YSM_TEMP_KEY_HANDLE, secret).get_hash()
@@ -46,9 +46,9 @@ def search_for_oath_code(hsm, key_handle, nonce, aead, counter, user_code, look_
 def truncate(hmac_result, length=6):
     """ Perform the truncating. """
     assert(len(hmac_result) == 20)
-    offset   =  ord(hmac_result[19]) & 0xf
-    bin_code = (ord(hmac_result[offset]) & 0x7f) << 24 \
-        | (ord(hmac_result[offset+1]) & 0xff) << 16 \
-        | (ord(hmac_result[offset+2]) & 0xff) <<  8 \
-        | (ord(hmac_result[offset+3]) & 0xff)
+    offset   =  hmac_result[19] & 0xf
+    bin_code = (hmac_result[offset] & 0x7f) << 24 \
+        | (hmac_result[offset+1] & 0xff) << 16 \
+        | (hmac_result[offset+2] & 0xff) <<  8 \
+        | (hmac_result[offset+3] & 0xff)
     return bin_code % (10 ** length)

--- a/pyhsm/stick_client.py
+++ b/pyhsm/stick_client.py
@@ -33,13 +33,13 @@ DEFAULT_PORT = 5348
 
 
 def pack_data(data):
-    if isinstance(data, basestring):
+    if isinstance(data, str):
         return data.encode('base64')
     return data
 
 
 def unpack_data(data):
-    if isinstance(data, basestring):
+    if isinstance(data, str):
         return data.decode('base64')
     elif isinstance(data, dict) and 'error' in data:
         return pyhsm.exception.YHSM_Error(data['error'])
@@ -52,7 +52,7 @@ def read_sock(sf):
 
 
 def write_sock(sf, cmd, *args):
-    json.dump([cmd] + map(pack_data, args), sf)
+    json.dump([cmd] + list(map(pack_data, args)), sf)
     sf.write("\n")
     sf.flush()
 

--- a/pyhsm/stick_daemon.py
+++ b/pyhsm/stick_daemon.py
@@ -41,13 +41,13 @@ COMMANDS = {
 context = daemon.DaemonContext()
 
 def pack_data(data):
-    if isinstance(data, basestring):
+    if isinstance(data, str):
         return data.encode('base64')
     return data
 
 
 def unpack_data(data):
-    if isinstance(data, basestring):
+    if isinstance(data, str):
         return data.decode('base64')
     return data
 
@@ -85,7 +85,7 @@ class YHSM_Stick_Server():
                                           args=(cs,))
                 thread.start()
         except Exception as e:
-            print e
+            print(e)
             sys.exit(1)
 
     def invoke(self, cmd, *args):
@@ -95,7 +95,7 @@ class YHSM_Stick_Server():
             res = getattr(self._stick, COMMANDS[cmd])(*args)
         except Exception as e:
             res = e
-            print e
+            print(e)
             self._stick = None
         return res
 
@@ -107,7 +107,7 @@ class YHSM_Stick_Server():
             while True:
                 data = json.loads(socket_file.readline())
                 cmd = data[0]
-                args = map(unpack_data, data[1:])
+                args = list(map(unpack_data, data[1:]))
                 if cmd == CMD_LOCK:
                     if not has_lock:
                         self.lock.acquire()
@@ -123,7 +123,7 @@ class YHSM_Stick_Server():
                         socket_file.flush()
                 else:
                     err = 'Command run without holding lock!'
-                    print err
+                    print(err)
                     json.dump({'error': err}, socket_file)
                     socket_file.write("\n")
                     socket_file.flush()
@@ -161,12 +161,12 @@ def main():
 
     args = parser.parse_args()
 
-    print 'Starting YubiHSM daemon for device: %s, listening on: %s:%d' % \
-        (args.device, args.interface, args.port)
+    print('Starting YubiHSM daemon for device: %s, listening on: %s:%d' % \
+        (args.device, args.interface, args.port))
 
     server = YHSM_Stick_Server(args.device, (args.interface, args.port))
-    print 'You can connect to the server using the following device string:'
-    print 'yhsm://127.0.0.1:%d' % args.port
+    print('You can connect to the server using the following device string:')
+    print('yhsm://127.0.0.1:%d' % args.port)
 
     server.pidfile = args.pid_file
     context.files_preserve = [server.socket]

--- a/pyhsm/tools/generate_keys.py
+++ b/pyhsm/tools/generate_keys.py
@@ -138,42 +138,42 @@ def gen_keys(hsm, args):
     """
 
     if args.verbose:
-        print "Generating %i keys :\n" % (args.count)
+        print("Generating %i keys :\n" % (args.count))
     else:
-        print "Generating %i keys" % (args.count)
+        print("Generating %i keys" % (args.count))
 
     for int_id in range(args.start_id, args.start_id + args.count):
         public_id = ("%x" % int_id).rjust(args.public_id_chars, '0')
         padded_id = pyhsm.yubikey.modhex_encode(public_id)
 
         if args.verbose:
-            print "  %s" % (padded_id)
+            print("  %s" % (padded_id))
 
-        num_bytes = len(pyhsm.aead_cmd.YHSM_YubiKeySecret('a' * 16, 'b' * 6).pack())
+        num_bytes = len(pyhsm.aead_cmd.YHSM_YubiKeySecret(b'a' * 16, b'b' * 6).pack())
         hsm.load_random(num_bytes)
-        for kh in args.key_handles.keys():
+        for kh in list(args.key_handles.keys()):
             if args.random_nonce:
-                nonce = ""
+                nonce = b""
             else:
-                nonce = public_id.decode('hex')
+                nonce = bytes.fromhex(public_id)
             aead = hsm.generate_aead(nonce, kh)
 
             filename = output_filename(args.output_dir, args.key_handles[kh], padded_id)
 
             if args.verbose:
-                print "    %4s, %i bytes (%s) -> %s" % \
-                    (args.key_handles[kh], len(aead.data), shorten_aead(aead), filename)
+                print("    %4s, %i bytes (%s) -> %s" % \
+                    (args.key_handles[kh], len(aead.data), shorten_aead(aead), filename))
             aead.save(filename)
 
         if args.verbose:
-            print ""
+            print("")
 
-    print "\nDone\n"
+    print("\nDone\n")
 
 def shorten_aead(aead):
     """ Produce pretty-printable version of long AEAD. """
-    head = aead.data[:4].encode('hex')
-    tail = aead.data[-4:].encode('hex')
+    head = aead.data[:4]
+    tail = aead.data[-4:]
     return "%s...%s" % (head, tail)
 
 def output_filename(output_dir, key_handle, public_id):
@@ -195,12 +195,12 @@ def main():
 
     args_fixup(args)
 
-    print "output dir		: %s" % (args.output_dir)
-    print "keys to generate	: %s" % (args.count)
-    print "key handles		: %s" % (args.key_handles)
-    print "start public_id		: %s (0x%x)" % (args.start_id, args.start_id)
-    print "YHSM device		: %s" % (args.device)
-    print ""
+    print("output dir		: %s" % (args.output_dir))
+    print("keys to generate	: %s" % (args.count))
+    print("key handles		: %s" % (args.key_handles))
+    print("start public_id		: %s (0x%x)" % (args.start_id, args.start_id))
+    print("YHSM device		: %s" % (args.device))
+    print("")
 
     if os.path.isfile(args.device):
         hsm = pyhsm.soft_hsm.SoftYHSM.from_file(args.device)

--- a/pyhsm/tools/keystore_unlock.py
+++ b/pyhsm/tools/keystore_unlock.py
@@ -67,12 +67,12 @@ def get_password(hsm, args):
             password = password[:-1]
     else:
         if args.debug:
-            password = raw_input('Enter %s (press enter to skip) (will be echoed) : ' % (name))
+            password = input('Enter %s (press enter to skip) (will be echoed) : ' % (name))
         else:
             password = getpass.getpass('Enter %s (press enter to skip) : ' % (name))
 
     if len(password) <= expected_len:
-        password = password.decode('hex')
+        password = bytes.fromhex(password)
         if not password:
             return None
         return password
@@ -91,7 +91,7 @@ def get_otp(hsm, args):
             while otp and otp[-1] == '\n':
                 otp = otp[:-1]
         else:
-            otp = raw_input('Enter admin YubiKey OTP (press enter to skip) : ')
+            otp = input('Enter admin YubiKey OTP (press enter to skip) : ')
         if len(otp) == 44:
             # YubiHSM admin OTP's always have a public_id length of 6 bytes
             return otp
@@ -109,25 +109,23 @@ def main():
         hsm = pyhsm.base.YHSM(device=args.device, debug=args.debug)
 
         if args.debug or args.verbose:
-            print "Device  : %s" % (args.device)
-            print "Version : %s" % (hsm.info())
-            print ""
+            print("Device  : %s" % (args.device))
+            print("Version : %s" % (hsm.info()))
+            print("")
 
         password = get_password(hsm, args)
         otp = get_otp(hsm, args)
         if not password and not otp:
-            print "\nAborted\n"
+            print("\nAborted\n")
             return 1
         else:
             if args.debug or args.verbose:
-                print ""
+                print("")
             if hsm.unlock(password = password, otp = otp):
                 if args.debug or args.verbose:
-                    print "OK\n"
-    except pyhsm.exception.YHSM_Error, e:
+                    print("OK\n")
+    except pyhsm.exception.YHSM_Error as e:
         sys.stderr.write("ERROR: %s\n" % (e.reason))
-        if e.reason == "YubiHSM did not respond to command YSM_SYSTEM_INFO_QUERY":
-            sys.stderr.write("Please check whether your YubiHSM is really at " + args.device + ", you can specify an alternate device using the option -D")
         return 1
 
     return 0

--- a/pyhsm/tools/linux_add_entropy.py
+++ b/pyhsm/tools/linux_add_entropy.py
@@ -72,7 +72,7 @@ def get_entropy(hsm, iterations, entropy_ratio):
     #    __u32   buf[0];
     # };
     fmt = 'ii%is' % (pyhsm.defines.YSM_MAX_PKT_SIZE - 1)
-    for _ in xrange(iterations):
+    for _ in range(iterations):
         rnd = hsm.random(pyhsm.defines.YSM_MAX_PKT_SIZE - 1)
         this = struct.pack(fmt, entropy_ratio * len(rnd), len(rnd), rnd)
         fcntl.ioctl(fd, RNDADDENTROPY, this)

--- a/pyhsm/val/init_oath_token.py
+++ b/pyhsm/val/init_oath_token.py
@@ -111,14 +111,14 @@ def generate_aead(hsm, args):
     nonce = hsm.get_nonce().nonce
     aead = hsm.generate_aead(nonce, args.key_handle)
     if args.debug:
-        print "AEAD: %s (%s)" % (aead.data.encode('hex'), aead)
+        print("AEAD: %s (%s)" % (aead.data, aead))
     return nonce, aead
 
 def validate_oath_c(hsm, args, nonce, aead):
     if args.test_code:
         if args.verbose:
-            print "Trying to validate the OATH counter value in the range %i..%i." \
-                % (args.oath_c, args.oath_c + args.look_ahead)
+            print("Trying to validate the OATH counter value in the range %i..%i." \
+                % (args.oath_c, args.oath_c + args.look_ahead))
         counter = pyhsm.oath_hotp.search_for_oath_code(hsm, args.key_handle, nonce, aead, \
                                                            args.oath_c, args.test_code, args.look_ahead \
                                                            )
@@ -127,21 +127,21 @@ def validate_oath_c(hsm, args, nonce, aead):
                                  % (args.test_code, args.oath_c, args.oath_c + args.look_ahead))
             sys.exit(1)
         if args.verbose:
-            print "OATH C==%i validated with code %s" % (counter - 1, args.test_code)
+            print("OATH C==%i validated with code %s" % (counter - 1, args.test_code))
         return counter
     return args.oath_c
 
 def get_oath_k(args):
     """ Get the OATH K value (secret key), either from args or by prompting. """
     if args.oath_k:
-        decoded = args.oath_k.decode('hex')
+        decoded = bytes.fromhex(args.oath_k)
     else:
-        t = raw_input("Enter OATH key (hex encoded) : ")
-        decoded = t.decode('hex')
+        t = input("Enter OATH key (hex encoded) : ")
+        decoded = bytes.fromhex(t)
 
     if len(decoded) > 20:
         decoded = sha1(decoded).digest()
-    decoded = decoded.ljust(20, '\0')
+    decoded = decoded.ljust(20, b'\0')
     return decoded
 
 class ValOathDb():
@@ -185,8 +185,8 @@ class ValOathEntry():
 def store_oath_entry(args, nonce, aead, oath_c):
     """ Store the AEAD in the database. """
     data = {"key": args.uid,
-            "aead": aead.data.encode('hex'),
-            "nonce": nonce.encode('hex'),
+            "aead": aead.data,
+            "nonce": nonce,
             "key_handle": args.key_handle,
             "oath_C": oath_c,
             "oath_T": None,
@@ -197,7 +197,7 @@ def store_oath_entry(args, nonce, aead, oath_c):
         if args.force:
             db.delete(entry)
         db.add(entry)
-    except sqlite3.IntegrityError, e:
+    except sqlite3.IntegrityError as e:
         sys.stderr.write("ERROR: %s\n" % (e))
         return False
     return True
@@ -207,9 +207,9 @@ def main():
 
     args_fixup(args)
 
-    print "Key handle		: %s" % (args.key_handle)
-    print "YHSM device		: %s" % (args.device)
-    print ""
+    print("Key handle		: %s" % (args.key_handle))
+    print("YHSM device		: %s" % (args.device))
+    print("")
 
     hsm = pyhsm.YHSM(device = args.device, debug=args.debug)
 

--- a/pyhsm/val/validate_otp.py
+++ b/pyhsm/val/validate_otp.py
@@ -65,12 +65,12 @@ def validate_otp(hsm, args):
     try:
         res = pyhsm.yubikey.validate_otp(hsm, args.otp)
         if args.verbose:
-            print "OK counter=%04x low=%04x high=%02x use=%02x" % \
-                (res.use_ctr, res.ts_low, res.ts_high, res.session_ctr)
+            print("OK counter=%04x low=%04x high=%02x use=%02x" % \
+                (res.use_ctr, res.ts_low, res.ts_high, res.session_ctr))
         return 0
-    except pyhsm.exception.YHSM_CommandFailed, e:
+    except pyhsm.exception.YHSM_CommandFailed as e:
         if args.verbose:
-            print "%s" % (pyhsm.defines.status2str(e.status))
+            print("%s" % (pyhsm.defines.status2str(e.status)))
         # figure out numerical response code
         for r in [pyhsm.defines.YSM_OTP_INVALID, \
                       pyhsm.defines.YSM_OTP_REPLAY, \
@@ -84,7 +84,7 @@ def validate_oath(hsm, args):
     """
     Validate an OATH OTP.
     """
-    print "ERROR: Not implemented, try 'yhsm-validation-server'."
+    print("ERROR: Not implemented, try 'yhsm-validation-server'.")
     return 0
 
 
@@ -92,8 +92,8 @@ def main():
     args = parse_args()
 
     if args.debug:
-        print "YHSM device		: %s" % (args.device)
-        print ""
+        print("YHSM device		: %s" % (args.device))
+        print("")
 
     hsm = pyhsm.YHSM(device = args.device, debug=args.debug)
 

--- a/pyhsm/validate_cmd.py
+++ b/pyhsm/validate_cmd.py
@@ -107,7 +107,7 @@ class YHSM_ValidationResult():
         return '<%s instance at %s: public_id=%s, use_ctr=%i, session_ctr=%i, ts=%i/%i>' % (
             self.__class__.__name__,
             hex(id(self)),
-            self.public_id.encode('hex'),
+            bytes.fromhex(self.public_id),
             self.use_ctr,
             self.session_ctr,
             self.ts_high,

--- a/pyhsm/yubikey.py
+++ b/pyhsm/yubikey.py
@@ -125,12 +125,16 @@ def split_id_otp(from_key):
     @returns: public_id and OTP
     @rtype: tuple of string
     """
-    if len(from_key) > 16:
-        public_id, otp = from_key[:-16], from_key[-16:]
-    elif len(from_key) == 16:
+    if type(from_key) == bytes:
+        from_key_len = 16
+    else:
+        from_key_len = 32
+    if len(from_key) > from_key_len:
+        public_id, otp = from_key[:-from_key_len], from_key[-from_key_len:]
+    elif len(from_key) == from_key_len:
         public_id = b''
         otp = from_key
     else:
-        raise pyhsm.exception.YHSM_Error("Bad from_key length %i < 16 : %s" \
-                                       % (len(from_key), from_key))
+        raise pyhsm.exception.YHSM_Error("Bad from_key length %i < %i : %s" \
+                                       % (len(from_key), from_key_len, from_key))
     return public_id, otp

--- a/pyhsm/yubikey.py
+++ b/pyhsm/yubikey.py
@@ -43,8 +43,8 @@ def validate_otp(hsm, from_key):
     @see: L{pyhsm.db_cmd.YHSM_Cmd_DB_Validate_OTP.parse_result}
     """
     public_id, otp = split_id_otp(from_key)
-    return hsm.db_validate_yubikey_otp(modhex_decode(public_id).decode('hex'),
-                                       modhex_decode(otp).decode('hex')
+    return hsm.db_validate_yubikey_otp(modhex_decode(public_id),
+                                       modhex_decode(otp)
                                        )
 
 def validate_yubikey_with_aead(hsm, from_key, aead, key_handle):
@@ -84,9 +84,9 @@ def validate_yubikey_with_aead(hsm, from_key, aead, key_handle):
     otp = modhex_decode(otp)
 
     if not nonce:
-        nonce = public_id.decode('hex')
+        nonce = bytes.fromhex(public_id)
 
-    return hsm.validate_aead_otp(nonce, otp.decode('hex'),
+    return hsm.validate_aead_otp(nonce, otp,
         key_handle, aead)
 
 def modhex_decode(data):
@@ -99,7 +99,7 @@ def modhex_decode(data):
     @returns: Hex
     @rtype: string
     """
-    t_map = string.maketrans("cbdefghijklnrtuv", "0123456789abcdef")
+    t_map = bytes.maketrans(b"cbdefghijklnrtuv", b"0123456789abcdef")
     return data.translate(t_map)
 
 def modhex_encode(data):
@@ -112,7 +112,7 @@ def modhex_encode(data):
     @returns: Modhex
     @rtype: string
     """
-    t_map = string.maketrans("0123456789abcdef", "cbdefghijklnrtuv")
+    t_map = bytes.maketrans(b"0123456789abcdef", b"cbdefghijklnrtuv")
     return data.translate(t_map)
 
 def split_id_otp(from_key):
@@ -125,12 +125,12 @@ def split_id_otp(from_key):
     @returns: public_id and OTP
     @rtype: tuple of string
     """
-    if len(from_key) > 32:
-        public_id, otp = from_key[:-32], from_key[-32:]
-    elif len(from_key) == 32:
-        public_id = ''
+    if len(from_key) > 16:
+        public_id, otp = from_key[:-16], from_key[-16:]
+    elif len(from_key) == 16:
+        public_id = b''
         otp = from_key
     else:
-        raise pyhsm.exception.YHSM_Error("Bad from_key length %i < 32 : %s" \
+        raise pyhsm.exception.YHSM_Error("Bad from_key length %i < 16 : %s" \
                                        % (len(from_key), from_key))
     return public_id, otp

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,8 @@ setup(
     test_suite='test.test_init',
     tests_require=[],
     install_requires=[
-        'pyserial >= 2.3',
-        'pycrypto >= 2.1'
+        'pyserial >= 3.4',
+        'pycryptodome >= 3.4.6'
     ],
     extras_require={
         'db': ['sqlalchemy'],

--- a/test/test_aead.py
+++ b/test/test_aead.py
@@ -5,24 +5,24 @@ import sys
 import unittest
 import pyhsm
 
-import test_common
+from . import test_common
 
 class TestAEAD(test_common.YHSM_TestCase):
 
     def setUp(self):
         test_common.YHSM_TestCase.setUp(self)
-        self.nonce = "4d4d4d4d4d4d".decode('hex')
-        self.key = "A" * 16
-        self.uid = '\x4d\x01\x4d\x02\x4d\x03'
+        self.nonce = bytes.fromhex('4d4d4d4d4d4d')
+        self.key = b"AAAAAAAAAAAAAAAA"
+        self.uid = bytes.fromhex('4d014d024d03')
         self.secret = pyhsm.aead_cmd.YHSM_YubiKeySecret(self.key, self.uid)
 
     def test_aead_cmd_class(self):
         """ Test YHSM_AEAD_Cmd class. """
         this = pyhsm.aead_cmd.YHSM_AEAD_Cmd(None, None)
         # test repr method
-        self.assertEquals(str, type(str(this)))
+        self.assertEqual(str, type(str(this)))
         this.executed = True
-        self.assertEquals(str, type(str(this)))
+        self.assertEqual(str, type(str(this)))
 
     def test_generate_aead_simple(self):
         """ Test generate_aead_simple without specifying nonce. """
@@ -30,14 +30,14 @@ class TestAEAD(test_common.YHSM_TestCase):
         # HSM> < keyload - Load key data now using flags 00000002. Press ESC to quit
         # 00000002 - stored ok
         key_handle = 2
-        nonce = ''
+        nonce = b''
         aead = self.hsm.generate_aead_simple(nonce, key_handle, self.secret)
 
         self.assertNotEqual(aead.nonce, nonce)
         self.assertEqual(aead.key_handle, key_handle)
 
         # test repr method
-        self.assertEquals(str, type(str(aead)))
+        self.assertEqual(str, type(str(aead)))
 
     def test_generate_aead_simple_with_nonce(self):
         """ Test generate_aead_simple with specified nonce. """
@@ -62,8 +62,8 @@ class TestAEAD(test_common.YHSM_TestCase):
         try:
             res = self.hsm.generate_aead_simple(self.nonce, key_handle, self.secret)
             self.fail("Expected YSM_FUNCTION_DISABLED, got %s" % (res))
-        except pyhsm.exception.YHSM_CommandFailed, e:
-            self.assertEquals(e.status, pyhsm.defines.YSM_FUNCTION_DISABLED)
+        except pyhsm.exception.YHSM_CommandFailed as e:
+            self.assertEqual(e.status, pyhsm.defines.YSM_FUNCTION_DISABLED)
 
     def test_generate_aead_simple_validates(self):
         """ Test validate_aead of generate_aead_simple result. """
@@ -72,7 +72,7 @@ class TestAEAD(test_common.YHSM_TestCase):
         kh_gen = 0x2000
         kh_val = 0x2000
 
-        aead = self.hsm.generate_aead_simple('', kh_gen, self.secret)
+        aead = self.hsm.generate_aead_simple(b'', kh_gen, self.secret)
 
         # test that the YubiHSM validates the generated AEAD
         # and confirms it contains our secret
@@ -86,7 +86,7 @@ class TestAEAD(test_common.YHSM_TestCase):
         kh_gen = 0x2000
         kh_val = 0x2000
 
-        nonce = '000000000000'.decode('hex')
+        nonce = bytes.fromhex('000000000000')
 
         aead = self.hsm.generate_aead_simple(nonce, kh_gen, self.secret)
 
@@ -106,8 +106,8 @@ class TestAEAD(test_common.YHSM_TestCase):
         try:
             res = self.hsm.generate_aead_random(self.nonce, key_handle, 22)
             self.fail("Expected YSM_FUNCTION_DISABLED, got %s" % (res))
-        except pyhsm.exception.YHSM_CommandFailed, e:
-            self.assertEquals(e.status, pyhsm.defines.YSM_FUNCTION_DISABLED)
+        except pyhsm.exception.YHSM_CommandFailed as e:
+            self.assertEqual(e.status, pyhsm.defines.YSM_FUNCTION_DISABLED)
 
     def test_generate_aead_random_nonce_permitted(self):
         """ Test generate_aead_random with nonce. """
@@ -127,7 +127,7 @@ class TestAEAD(test_common.YHSM_TestCase):
         # 00000004 - stored ok
         key_handle = 4
 
-        nonce = ''
+        nonce = b''
 
         # Test a number of different sizes
         for num_bytes in (1, \
@@ -143,8 +143,8 @@ class TestAEAD(test_common.YHSM_TestCase):
             try:
                 res = self.hsm.generate_aead_random(nonce, key_handle, num_bytes)
                 self.fail("Expected YSM_INVALID_PARAMETER, got %s" % (res))
-            except pyhsm.exception.YHSM_CommandFailed, e:
-                self.assertEquals(e.status, pyhsm.defines.YSM_INVALID_PARAMETER)
+            except pyhsm.exception.YHSM_CommandFailed as e:
+                self.assertEqual(e.status, pyhsm.defines.YSM_INVALID_PARAMETER)
 
     def test_who_can_generate_random(self):
         """ Test what key handles can generate a random AEAD. """
@@ -169,7 +169,7 @@ class TestAEAD(test_common.YHSM_TestCase):
         gen_kh = 2
         # Enabled flags 00000010 = YSM_AEAD_DECRYPT_CMP
         # 00000005 - stored ok
-        aead = self.hsm.generate_aead_simple('', gen_kh, self.secret)
+        aead = self.hsm.generate_aead_simple(b'', gen_kh, self.secret)
 
         this = lambda kh: self.hsm.validate_aead(aead.nonce, kh, \
                                                      aead, cleartext = self.secret.pack())

--- a/test/test_aes_ecb.py
+++ b/test/test_aes_ecb.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 import pyhsm
 
-import test_common
+from . import test_common
 
 class TestOtpValidate(test_common.YHSM_TestCase):
 
@@ -20,13 +20,13 @@ class TestOtpValidate(test_common.YHSM_TestCase):
         """ Test YHSM_Cmd_AES_ECB class. """
         this = pyhsm.aes_ecb_cmd.YHSM_Cmd_AES_ECB(None, None, '')
         # test repr method
-        self.assertEquals(str, type(str(this)))
+        self.assertEqual(str, type(str(this)))
         this.executed = True
-        self.assertEquals(str, type(str(this)))
+        self.assertEqual(str, type(str(this)))
 
     def test_encrypt_decrypt(self):
         """ Test to AES ECB decrypt something encrypted. """
-        plaintext = 'Fjaellen 2011'.ljust(pyhsm.defines.YSM_BLOCK_SIZE)	# pad for compare after decrypt
+        plaintext = b'Fjaellen 2011'.ljust(pyhsm.defines.YSM_BLOCK_SIZE)# pad for compare after decrypt
 
         ciphertext = self.hsm.aes_ecb_encrypt(self.kh_encrypt, plaintext)
 
@@ -38,20 +38,20 @@ class TestOtpValidate(test_common.YHSM_TestCase):
 
     def test_compare(self):
         """ Test to AES ECB decrypt and then compare something. """
-        plaintext = 'Maverick'.ljust(pyhsm.defines.YSM_BLOCK_SIZE)
+        plaintext = b'Maverick'.ljust(pyhsm.defines.YSM_BLOCK_SIZE)
 
         ciphertext = self.hsm.aes_ecb_encrypt(self.kh_encrypt, plaintext)
 
         self.assertTrue(self.hsm.aes_ecb_compare(self.kh_compare, ciphertext, plaintext))
-        self.assertFalse(self.hsm.aes_ecb_compare(self.kh_compare, ciphertext, plaintext[:-1] + 'x'))
+        self.assertFalse(self.hsm.aes_ecb_compare(self.kh_compare, ciphertext, plaintext[:-1] + b'x'))
 
     def test_compare_bad(self):
         """ Test AES decrypt compare with incorrect plaintext. """
-        plaintext = 'Maverick'.ljust(pyhsm.defines.YSM_BLOCK_SIZE)
+        plaintext = b'Maverick'.ljust(pyhsm.defines.YSM_BLOCK_SIZE)
 
         ciphertext = self.hsm.aes_ecb_encrypt(self.kh_encrypt, plaintext)
 
-        self.assertFalse(self.hsm.aes_ecb_compare(self.kh_compare, ciphertext, plaintext[:-1] + 'x'))
+        self.assertFalse(self.hsm.aes_ecb_compare(self.kh_compare, ciphertext, plaintext[:-1] + b'x'))
 
     def test_who_can_encrypt(self):
         """ Test what key handles can encrypt AES ECB encrypted blocks. """
@@ -59,7 +59,7 @@ class TestOtpValidate(test_common.YHSM_TestCase):
         # 0000000e - stored ok
         kh_enc = 0x0e
 
-        plaintext = 'sommar'
+        plaintext = b'sommar'
 
         this = lambda kh: self.hsm.aes_ecb_encrypt(kh, plaintext)
         self.who_can(this, expected = [kh_enc])
@@ -74,7 +74,7 @@ class TestOtpValidate(test_common.YHSM_TestCase):
         # 0000000f - stored ok
         kh_dec = 0x0f
 
-        plaintext = 'sommar'
+        plaintext = b'sommar'
         ciphertext = self.hsm.aes_ecb_encrypt(kh_enc, plaintext)
 
         this = lambda kh: self.hsm.aes_ecb_decrypt(kh, ciphertext)
@@ -96,7 +96,7 @@ class TestOtpValidate(test_common.YHSM_TestCase):
         # 0000000f - stored ok
         kh_dec = 0x0f
 
-        plaintext = 'sommar'
+        plaintext = b'sommar'
         ciphertext = self.hsm.aes_ecb_encrypt(kh_enc, plaintext)
 
         this = lambda kh: self.hsm.aes_ecb_decrypt(kh, ciphertext)
@@ -107,26 +107,26 @@ class TestOtpValidate(test_common.YHSM_TestCase):
         if self.hsm.version.ver <= (0, 9, 8,):
             print ("Test for known bug in 0.9.8 disabled.")
             return None
-        cleartext = "reference"
+        cleartext = b"reference"
         res_before = self.hsm.aes_ecb_encrypt(0x2000, cleartext)
         # lock key store
         try:
-            res = self.hsm.key_storage_unlock("A" * 8)
+            res = self.hsm.key_storage_unlock(b"A" * 8)
             self.fail("Expected YSM_MISMATCH/YSM_KEY_STORAGE_LOCKED, got %s" % (res))
-        except pyhsm.exception.YHSM_CommandFailed, e:
+        except pyhsm.exception.YHSM_CommandFailed as e:
             if self.hsm.version.have_key_store_decrypt():
-                self.assertEquals(e.status, pyhsm.defines.YSM_MISMATCH)
+                self.assertEqual(e.status, pyhsm.defines.YSM_MISMATCH)
             else:
-                self.assertEquals(e.status, pyhsm.defines.YSM_KEY_STORAGE_LOCKED)
+                self.assertEqual(e.status, pyhsm.defines.YSM_KEY_STORAGE_LOCKED)
         # make sure we can't AES encrypt when keystore is locked
         try:
             res = self.hsm.aes_ecb_encrypt(0x2000, cleartext)
             self.fail("Expected YSM_KEY_STORAGE_LOCKED, got %s (before lock: %s)" \
-                          % (res.encode("hex"), res_before.encode("hex")))
-        except pyhsm.exception.YHSM_CommandFailed, e:
-            self.assertEquals(e.status, pyhsm.defines.YSM_KEY_STORAGE_LOCKED)
+                          % (res, res_before))
+        except pyhsm.exception.YHSM_CommandFailed as e:
+            self.assertEqual(e.status, pyhsm.defines.YSM_KEY_STORAGE_LOCKED)
         # unlock key store with correct passphrase
-        self.assertTrue(self.hsm.key_storage_unlock(test_common.HsmPassphrase.decode("hex")))
+        self.assertTrue(self.hsm.key_storage_unlock(bytes.fromhex(test_common.HsmPassphrase)))
         # make sure it is properly unlocked
         res_after = self.hsm.aes_ecb_encrypt(0x2000, cleartext)
-        self.assertEquals(res_before, res_after)
+        self.assertEqual(res_before, res_after)

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -7,7 +7,7 @@ import pyhsm
 import serial
 import struct
 
-import test_common
+from . import test_common
 
 class TestBasics(test_common.YHSM_TestCase):
 
@@ -16,7 +16,7 @@ class TestBasics(test_common.YHSM_TestCase):
 
     def test_echo(self):
         """ Test echo command. """
-        self.assertTrue(self.hsm.echo('test'))
+        self.assertTrue(self.hsm.echo(b'test'))
 
     def test_random(self):
         """ Test random number generator . """
@@ -48,14 +48,14 @@ class TestBasics(test_common.YHSM_TestCase):
     def test_nonce_class(self):
         """ Test nonce class. """
         # test repr method
-        self.assertEquals(str, type(str(self.hsm.get_nonce(0))))
+        self.assertEqual(str, type(str(self.hsm.get_nonce(0))))
 
     def test_random_reseed(self):
         """
         Tets random reseed.
         """
         # Unsure if we can test anything except the status returned is OK
-        self.assertTrue(self.hsm.random_reseed('A' * 32))
+        self.assertTrue(self.hsm.random_reseed(b'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'))
         # at least test we didn't disable the RNG
         r1 = self.hsm.random(10)
         r2 = self.hsm.random(10)
@@ -63,14 +63,14 @@ class TestBasics(test_common.YHSM_TestCase):
 
     def test_load_temp_key(self):
         """ Test load_temp_key. """
-        key = "A" * 16
-        uid = '\x4d\x01\x4d\x02'
-        nonce = 'f1f2f3f4f5f6'.decode('hex')
+        key = b"AAAAAAAAAAAAAAAA" 
+        uid = b'\x4d\x01\x4d\x02'
+        nonce = bytes.fromhex('f1f2f3f4f5f6')
         # key 0x2000 has all flags set
         key_handle = 0x2000
 
         my_flags = struct.pack("< I", 0xffffffff) # full permissions when loaded into phantom key handle
-        my_key = 'C' * pyhsm.defines.YSM_MAX_KEY_SIZE
+        my_key = b'C' * pyhsm.defines.YSM_MAX_KEY_SIZE
         self.hsm.load_secret(my_key + my_flags)
 
         aead = self.hsm.generate_aead(nonce, key_handle)
@@ -81,7 +81,7 @@ class TestBasics(test_common.YHSM_TestCase):
         self.assertTrue(self.hsm.load_temp_key(nonce, key_handle, aead))
 
         # Encrypt something with the phantom key
-        plaintext = 'Testing'.ljust(pyhsm.defines.YSM_BLOCK_SIZE)	# pad for compare after decrypt
+        plaintext = b'Testing'.ljust(pyhsm.defines.YSM_BLOCK_SIZE)	# pad for compare after decrypt
         ciphertext = self.hsm.aes_ecb_encrypt(pyhsm.defines.YSM_TEMP_KEY_HANDLE, plaintext)
         self.assertNotEqual(plaintext, ciphertext)
 
@@ -92,12 +92,12 @@ class TestBasics(test_common.YHSM_TestCase):
     def test_yhsm_class(self):
         """ Test YHSM class. """
         # test repr method
-        self.assertEquals(str, type(str(self.hsm)))
+        self.assertEqual(str, type(str(self.hsm)))
 
     def test_yhsm_stick_class(self):
         """ Test YHSM_Stick class. """
         # test repr method
-        self.assertEquals(str, type(str(self.hsm.stick)))
+        self.assertEqual(str, type(str(self.hsm.stick)))
 
     def test_set_debug(self):
         """ Test set_debug on YHSM. """
@@ -115,14 +115,14 @@ class TestBasics(test_common.YHSM_TestCase):
         """ Test YHSM_Cmd_System_Info class. """
         this = pyhsm.basic_cmd.YHSM_Cmd_System_Info(None)
         # test repr method
-        self.assertEquals(str, type(str(this)))
+        self.assertEqual(str, type(str(this)))
 
     def test_sysinfo(self):
         """ Test sysinfo. """
         info = self.hsm.info()
         self.assertTrue(info.version_major > 0 or info.version_minor > 0)
         self.assertEqual(12, len(info.system_uid))
-        self.assertEquals(str, type(str(info)))
+        self.assertEqual(str, type(str(info)))
 
     def test_drain(self):
         """ Test YubiHSM drain. """

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 import pyhsm
 
-import test_common
+from . import test_common
 
 class TestBuffer(test_common.YHSM_TestCase):
 
@@ -14,7 +14,7 @@ class TestBuffer(test_common.YHSM_TestCase):
 
     def test_load_random(self):
         """ Test load_random. """
-        nonce = "abc123"
+        nonce = b"abc123"
         # key 0x2000 has all flags set
         key_handle = 0x2000
         self.hsm.load_random(16)
@@ -29,7 +29,7 @@ class TestBuffer(test_common.YHSM_TestCase):
 
     def test_would_overflow_buffer(self):
         """ Test overflow of buffer. """
-        nonce = "abc123"
+        nonce = b"abc123"
         # key 0x2000 has all flags set
         key_handle = 0x2000
 
@@ -42,14 +42,14 @@ class TestBuffer(test_common.YHSM_TestCase):
 
     def test_load_data(self):
         """ Test loading data into buffer. """
-        c1 = self.hsm.load_data('Samp', offset = 0)
+        c1 = self.hsm.load_data(b'Samp', offset = 0)
         self.assertEqual(c1, 4)
-        c2 = self.hsm.load_data('123', offset = 3)
+        c2 = self.hsm.load_data(b'123', offset = 3)
         self.assertEqual(c2, 6)
-        c3 = self.hsm.load_data('ple #2', offset = 3)
+        c3 = self.hsm.load_data(b'ple #2', offset = 3)
         self.assertEqual(c3, 9)
-        nonce = "abc123"
+        nonce = b"abc123"
         # key 0x2000 has all flags set
         key_handle = 0x2000
         aead = self.hsm.generate_aead(nonce, key_handle)
-        self.assertEqual(aead.data.encode('hex'), '18a88fbd7bd2275ba0a722bf80423ffab7')
+        self.assertEqual(aead.data, bytes.fromhex('18a88fbd7bd2275ba0a722bf80423ffab7'))

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -6,17 +6,17 @@ import sys
 import unittest
 import pyhsm
 
-import test_common
+from . import test_common
 
-from test_yubikey_validate import YubiKeyEmu
+from .test_yubikey_validate import YubiKeyEmu
 
 class TestInternalDB(test_common.YHSM_TestCase):
 
     def setUp(self):
         test_common.YHSM_TestCase.setUp(self)
-        self.key = "A" * 16
-        self.uid = 'f0f1f2f3f4f5'.decode('hex')
-        self.public_id = '4d4d4d4d4d4d'.decode('hex')
+        self.key = b"AAAAAAAAAAAAAAAA" 
+        self.uid = bytes.fromhex('f0f1f2f3f4f5')
+        self.public_id = bytes.fromhex('4d4d4d4d4d4d')
 
     def test_store_yubikey(self):
         """ Test storing a YubiKey in the internal database. """
@@ -32,14 +32,14 @@ class TestInternalDB(test_common.YHSM_TestCase):
         # always zap the configuration before running the test suite.
         try:
             self.assertTrue(self.hsm.db_store_yubikey(self.public_id, key_handle, aead))
-        except pyhsm.exception.YHSM_CommandFailed, e:
+        except pyhsm.exception.YHSM_CommandFailed as e:
             self.assertEqual(e.status, pyhsm.defines.YSM_ID_DUPLICATE)
 
         # Now, try an invalid validation against that record
         try:
-            res = self.hsm.db_validate_yubikey_otp(self.public_id, "x" * 16)
+            res = self.hsm.db_validate_yubikey_otp(self.public_id, B"x" * 16)
             self.fail("Expected YSM_OTP_INVALID, got %s" % (res))
-        except pyhsm.exception.YHSM_CommandFailed, e:
+        except pyhsm.exception.YHSM_CommandFailed as e:
             self.assertEqual(e.status, pyhsm.defines.YSM_OTP_INVALID)
 
     def test_store_yubikey_with_nonce(self):
@@ -48,10 +48,10 @@ class TestInternalDB(test_common.YHSM_TestCase):
             raise unittest.SkipTest("Test of command introduced in 1.0.4 disabled.")
         # Key handle 0x2000 has all flags enabled
         key_handle = 0x2000
-        public_id = '4d4d4d001122'.decode('hex')
-        nonce = '010203040506'.decode('hex')
-        key = 'T' * 16
-        uid = 'F' * 6
+        public_id = bytes.fromhex('4d4d4d001122')
+        nonce = bytes.fromhex('010203040506')
+        key = b'T' * 16
+        uid = b'F' * 6
 
         secret = pyhsm.aead_cmd.YHSM_YubiKeySecret(key, uid)
         self.hsm.load_secret(secret)
@@ -62,14 +62,14 @@ class TestInternalDB(test_common.YHSM_TestCase):
         # always zap the configuration before running the test suite.
         try:
             self.assertTrue(self.hsm.db_store_yubikey(public_id, key_handle, aead, nonce = nonce))
-        except pyhsm.exception.YHSM_CommandFailed, e:
+        except pyhsm.exception.YHSM_CommandFailed as e:
             self.assertEqual(e.status, pyhsm.defines.YSM_ID_DUPLICATE)
 
         # Now, try an invalid validation against that record
         try:
-            res = self.hsm.db_validate_yubikey_otp(public_id, "x" * 16)
+            res = self.hsm.db_validate_yubikey_otp(public_id, b"x" * 16)
             self.fail("Expected YSM_OTP_INVALID, got %s" % (res))
-        except pyhsm.exception.YHSM_CommandFailed, e:
+        except pyhsm.exception.YHSM_CommandFailed as e:
             self.assertEqual(e.status, pyhsm.defines.YSM_OTP_INVALID)
 
     def test_real_validate(self):
@@ -90,7 +90,7 @@ class TestInternalDB(test_common.YHSM_TestCase):
         # always zap the configuration before running the test suite.
         try:
             self.assertTrue(self.hsm.db_store_yubikey(this_public_id, key_handle, aead))
-        except pyhsm.exception.YHSM_CommandFailed, e:
+        except pyhsm.exception.YHSM_CommandFailed as e:
             self.assertEqual(e.status, pyhsm.defines.YSM_ID_DUPLICATE)
 
         # OK, now we know there is an entry for this_public_id in the database -
@@ -107,7 +107,7 @@ class TestInternalDB(test_common.YHSM_TestCase):
                 self.assertEqual(res.use_ctr, use_ctr)
                 # OK - if we got here we've got a successful response for this OTP
                 break
-            except pyhsm.exception.YHSM_CommandFailed, e:
+            except pyhsm.exception.YHSM_CommandFailed as e:
                 if e.status != pyhsm.defines.YSM_OTP_REPLAY:
                     raise
             # don't bother with the session_ctr - test run 5 would mean we first have to
@@ -120,7 +120,7 @@ class TestInternalDB(test_common.YHSM_TestCase):
         try:
             res = self.hsm.db_validate_yubikey_otp(this_public_id, otp)
             self.fail("Expected YSM_OTP_REPLAY, got %s" % (res))
-        except pyhsm.exception.YHSM_CommandFailed, e:
+        except pyhsm.exception.YHSM_CommandFailed as e:
             if e.status != pyhsm.defines.YSM_OTP_REPLAY:
                 raise
 

--- a/test/test_hmac.py
+++ b/test/test_hmac.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 import pyhsm
 
-import test_common
+from . import test_common
 
 class TestHMACSHA1(test_common.YHSM_TestCase):
 
@@ -17,61 +17,61 @@ class TestHMACSHA1(test_common.YHSM_TestCase):
 
     def test_nist_test_vector(self):
         """ Test HMAC SHA1 with NIST PUB 198 A.2 test vector. """
-        data = 'Sample #2'
+        data = b'Sample #2'
 
         this = self.hsm.hmac_sha1(self.kh, data).execute()
-        self.assertEquals(this.get_hash().encode('hex'), '0922d3405faa3d194f82a45830737d5cc6c75d24')
+        self.assertEqual(this.get_hash(), bytes.fromhex('0922d3405faa3d194f82a45830737d5cc6c75d24'))
 
         # test of repr method
-        self.assertEquals(str, type(str(this)))
+        self.assertEqual(str, type(str(this)))
 
     def test_hmac_numeric_flags(self):
         """ Test HMAC SHA1 with numeric flags. """
-        data = 'Sample #2'
+        data = b'Sample #2'
 
         flags = pyhsm.defines.YSM_HMAC_SHA1_RESET | pyhsm.defines.YSM_HMAC_SHA1_FINAL
         this = self.hsm.hmac_sha1(self.kh, data, flags = flags).execute()
-        self.assertEquals(this.get_hash().encode('hex'), '0922d3405faa3d194f82a45830737d5cc6c75d24')
+        self.assertEqual(this.get_hash(), bytes.fromhex('0922d3405faa3d194f82a45830737d5cc6c75d24'))
 
     def test_hmac_continuation(self):
         """ Test HMAC continuation. """
-        data = 'Sample #2'
+        data = b'Sample #2'
 
         this = self.hsm.hmac_sha1(self.kh, data[:3], final = False)
-        self.assertEquals(this.get_hash().encode('hex'), '00' * 20)
+        self.assertEqual(this.get_hash(), '\x00' * 20)
         this.next(data[3:], final = True).execute()
-        self.assertEquals(this.get_hash().encode('hex'), '0922d3405faa3d194f82a45830737d5cc6c75d24')
+        self.assertEqual(this.get_hash(), bytes.fromhex('0922d3405faa3d194f82a45830737d5cc6c75d24'))
 
     def test_hmac_continuation2(self):
         """ Test HMAC nasty continuation. """
-        data = 'Sample #2'
+        data = b'Sample #2'
 
-        this = self.hsm.hmac_sha1(self.kh, '', final = False)
-        self.assertEquals(this.get_hash().encode('hex'), '00' * 20)
+        this = self.hsm.hmac_sha1(self.kh, b'', final = False)
+        self.assertEqual(this.get_hash(), '\x00' * 20)
         this.next(data[:3], final = False).execute()
         this.next(data[3:], final = False).execute()
-        this.next('', final = True).execute()
-        self.assertEquals(this.get_hash().encode('hex'), '0922d3405faa3d194f82a45830737d5cc6c75d24')
+        this.next(b'', final = True).execute()
+        self.assertEqual(this.get_hash(), bytes.fromhex('0922d3405faa3d194f82a45830737d5cc6c75d24'))
 
     def test_hmac_interrupted(self):
         """ Test interrupted HMAC. """
-        data = 'Sample #2'
+        data = b'Sample #2'
 
         this = self.hsm.hmac_sha1(self.kh, data[:3], final = False)
-        self.assertEquals(this.get_hash().encode('hex'), '00' * 20)
-        self.assertTrue(self.hsm.echo('hmac unit test'))
+        self.assertEqual(this.get_hash(), '\x00' * 20)
+        self.assertTrue(self.hsm.echo(b'hmac unit test'))
         this.next(data[3:], final = True).execute()
-        self.assertEquals(this.get_hash().encode('hex'), '0922d3405faa3d194f82a45830737d5cc6c75d24')
+        self.assertEqual(this.get_hash(), bytes.fromhex('0922d3405faa3d194f82a45830737d5cc6c75d24'))
 
     def test_hmac_interrupted2(self):
         """ Test AES-interrupted HMAC. """
-        data = 'Sample #2'
-        plaintext = 'Maverick'.ljust(pyhsm.defines.YSM_BLOCK_SIZE)
+        data = b'Sample #2'
+        plaintext = b'Maverick'.ljust(pyhsm.defines.YSM_BLOCK_SIZE)
         kh_encrypt = 0x1001
         kh_decrypt = 0x1001
 
         this = self.hsm.hmac_sha1(self.kh, data[:3], final = False)
-        self.assertEquals(this.get_hash().encode('hex'), '00' * 20)
+        self.assertEqual(this.get_hash(), '\x00' * 20)
         # AES encrypt-decrypt in the middle of HMAC calculation
         ciphertext = self.hsm.aes_ecb_encrypt(kh_encrypt, plaintext)
         self.assertNotEqual(plaintext, ciphertext)
@@ -79,21 +79,21 @@ class TestHMACSHA1(test_common.YHSM_TestCase):
         self.assertEqual(plaintext, decrypted)
         # continue HMAC
         this.next(data[3:], final = True).execute()
-        self.assertEquals(this.get_hash().encode('hex'), '0922d3405faa3d194f82a45830737d5cc6c75d24')
+        self.assertEqual(this.get_hash(), bytes.fromhex('0922d3405faa3d194f82a45830737d5cc6c75d24'))
 
     def test_hmac_wrong_key_handle(self):
         """ Test HMAC SHA1 operation with wrong key handle. """
         try:
-            res = self.hsm.hmac_sha1(0x01, 'foo').execute()
+            res = self.hsm.hmac_sha1(0x01, b'foo').execute()
             self.fail("Expected YSM_FUNCTION_DISABLED, got %s" % (res))
-        except pyhsm.exception.YHSM_CommandFailed, e:
-            self.assertEquals(e.status, pyhsm.defines.YSM_FUNCTION_DISABLED)
+        except pyhsm.exception.YHSM_CommandFailed as e:
+            self.assertEqual(e.status, pyhsm.defines.YSM_FUNCTION_DISABLED)
 
     def test_who_can_hash(self):
         """ Test what key handles can create HMAC SHA1 hashes. """
         # Enabled flags 00010000 = YSM_HMAC_SHA1_GENERATE
         # 00000011 - stored ok
-        data = 'Sample #2'
+        data = b'Sample #2'
 
         this = lambda kh: self.hsm.hmac_sha1(kh, data).execute()
         self.who_can(this, expected = [0x11])
@@ -102,27 +102,27 @@ class TestHMACSHA1(test_common.YHSM_TestCase):
         """ Test YHSM_GeneratedHMACSHA1 class. """
         this = pyhsm.hmac_cmd.YHSM_GeneratedHMACSHA1(0x0, 'a' * 20, True)
         # test repr method
-        self.assertEquals(str, type(str(this)))
+        self.assertEqual(str, type(str(this)))
 
     def test_sha1_to_buffer(self):
         """ Test HMAC SHA1 to internal buffer. """
         self.assertEqual(0, self.hsm.load_random(0, offset = 0)) # offset = 0 clears buffer
 
-        self.hsm.hmac_sha1(self.kh, 'testing is fun!', to_buffer = True)
+        self.hsm.hmac_sha1(self.kh, b'testing is fun!', to_buffer = True)
         # Verify there is now 20 bytes in the buffer
         self.assertEqual(pyhsm.defines.YSM_SHA1_HASH_SIZE, self.hsm.load_random(0, offset = 1))
 
     def test_hmac_continuation_with_buffer(self):
         """ Test HMAC continuation with buffer. """
-        data = 'Sample #2'
+        data = b'Sample #2'
 
         self.assertEqual(0, self.hsm.load_random(0, offset = 0)) # offset = 0 clears buffer
         self.assertEqual(0, self.hsm.load_random(0, offset = 1))
 
-        this = self.hsm.hmac_sha1(self.kh, '', final = False)
-        self.assertEquals(this.get_hash().encode('hex'), '00' * 20)
+        this = self.hsm.hmac_sha1(self.kh, b'', final = False)
+        self.assertEqual(this.get_hash(), '\x00' * 20)
         this.next(data[:3], final = False).execute()
         this.next(data[3:], final = False).execute()
-        this.next('', final = True, to_buffer = True).execute()
+        this.next(b'', final = True, to_buffer = True).execute()
         # Verify there is now 20 bytes in the buffer
         self.assertEqual(pyhsm.defines.YSM_SHA1_HASH_SIZE, self.hsm.load_random(0, offset = 1))

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -21,24 +21,23 @@ from . import test_misc
 from . import test_soft_hsm
 from . import configure_hsm
 
-test_modules = [#configure_hsm,
-                test_aead, #ok
-                test_aes_ecb, #ok
-                test_basics, #ok
-                test_buffer, #ok
-                test_db, #ok
-                test_hmac, #ok
-                test_oath, #ok
-                test_otp_validate, #ok
-                test_stick, #ok
-                test_util, #ok
-                test_yubikey_validate, #ok
-                test_misc, #ok
-                test_soft_hsm, #kazkas blogai su crypto, ziuret kaip counteri pakeist i dict(able) objecta, nes kazkodel baitai netinka
+test_modules = [test_aead, 
+                test_aes_ecb, 
+                test_basics, 
+                test_buffer, 
+                test_db, 
+                test_hmac, 
+                test_oath, 
+                test_otp_validate, 
+                test_stick, 
+                test_util, 
+                test_yubikey_validate, 
+                test_misc, 
+                test_soft_hsm, 
                 ]
 
 # special, should not be addded to test_modules
-
+import configure_hsm
 
 
 def suite():

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -6,37 +6,39 @@ import sys
 import unittest
 import pyhsm
 
-import test_aead
-import test_aes_ecb
-import test_basics
-import test_buffer
-import test_db
-import test_hmac
-import test_oath
-import test_otp_validate
-import test_stick
-import test_util
-import test_yubikey_validate
-import test_misc
-import test_soft_hsm
+from . import test_aead
+from . import test_aes_ecb
+from . import test_basics
+from . import test_buffer
+from . import test_db
+from . import test_hmac
+from . import test_oath
+from . import test_otp_validate
+from . import test_stick
+from . import test_util
+from . import test_yubikey_validate
+from . import test_misc
+from . import test_soft_hsm
+from . import configure_hsm
 
-test_modules = [test_aead,
-                test_aes_ecb,
-                test_basics,
-                test_buffer,
-                test_db,
-                test_hmac,
-                test_oath,
-                test_otp_validate,
-                test_stick,
-                test_util,
-                test_yubikey_validate,
-                test_misc,
-                test_soft_hsm,
+test_modules = [#configure_hsm,
+                test_aead, #ok
+                test_aes_ecb, #ok
+                test_basics, #ok
+                test_buffer, #ok
+                test_db, #ok
+                test_hmac, #ok
+                test_oath, #ok
+                test_otp_validate, #ok
+                test_stick, #ok
+                test_util, #ok
+                test_yubikey_validate, #ok
+                test_misc, #ok
+                test_soft_hsm, #kazkas blogai su crypto, ziuret kaip counteri pakeist i dict(able) objecta, nes kazkodel baitai netinka
                 ]
 
 # special, should not be addded to test_modules
-import configure_hsm
+
 
 
 def suite():
@@ -52,9 +54,9 @@ def suite():
 
     # Check if we have a YubiHSM present, and start with locking it's keystore
     # XXX produce a better error message than 'error: None' when initializing fails
-    hsm = pyhsm.YHSM(device = os.getenv('YHSM_DEVICE', '/dev/ttyACM0'))
+    hsm = pyhsm.YHSM(device = os.getenv('YHSM_DEVICE', '/dev/tty.usbmodem25142549281'))
     try:
-        hsm.unlock("BADPASSPHRASE99")
+        hsm.unlock(b"BADPASSPHRASE99")
     except pyhsm.exception.YHSM_CommandFailed as e:
         if hsm.version.have_key_store_decrypt():
             if e.status != pyhsm.defines.YSM_MISMATCH:

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -54,7 +54,7 @@ def suite():
 
     # Check if we have a YubiHSM present, and start with locking it's keystore
     # XXX produce a better error message than 'error: None' when initializing fails
-    hsm = pyhsm.YHSM(device = os.getenv('YHSM_DEVICE', '/dev/tty.usbmodem25142549281'))
+    hsm = pyhsm.YHSM(device = os.getenv('YHSM_DEVICE', '/dev/ttyACM0'))
     try:
         hsm.unlock(b"BADPASSPHRASE99")
     except pyhsm.exception.YHSM_CommandFailed as e:

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 import pyhsm
 
-import test_common
+from . import test_common
 
 class TestUtil(test_common.YHSM_TestCase):
 
@@ -20,37 +20,37 @@ class TestUtil(test_common.YHSM_TestCase):
         # 00002001 - stored ok
         # HSM> < keydis 2001
         try:
-            res = self.hsm.aes_ecb_encrypt(0x2001, "klartext")
+            res = self.hsm.aes_ecb_encrypt(0x2001, b"klartext")
             self.fail("Expected YSM_FUNCTION_DISABLED, got %s" % (res))
-        except pyhsm.exception.YHSM_CommandFailed, e:
-            self.assertEquals(e.status, pyhsm.defines.YSM_FUNCTION_DISABLED)
+        except pyhsm.exception.YHSM_CommandFailed as e:
+            self.assertEqual(e.status, pyhsm.defines.YSM_FUNCTION_DISABLED)
 
     def test_keystore_unlock(self):
         """ Test locking and then unlocking keystore. """
         if self.hsm.version.ver <= (0, 9, 8,):
             print ("Test for known bug in 0.9.8 disabled.")
             return None
-        cleartext = "reference"
-        nonce = '010203040506'.decode('hex')
+        cleartext = b"reference"
+        nonce = bytes.fromhex('010203040506')
         res_before = self.hsm.generate_aead_simple(nonce, 0x2000, cleartext)
         # lock key store
         try:
-            res = self.hsm.key_storage_unlock("A" * 8)
+            res = self.hsm.key_storage_unlock(b"A" * 8)
             self.fail("Expected YSM_MISMATCH/YSM_KEY_STORAGE_LOCKED, got %s" % (res))
-        except pyhsm.exception.YHSM_CommandFailed, e:
+        except pyhsm.exception.YHSM_CommandFailed as e:
             if self.hsm.version.have_key_store_decrypt():
-                self.assertEquals(e.status, pyhsm.defines.YSM_MISMATCH)
+                self.assertEqual(e.status, pyhsm.defines.YSM_MISMATCH)
             else:
-                self.assertEquals(e.status, pyhsm.defines.YSM_KEY_STORAGE_LOCKED)
+                self.assertEqual(e.status, pyhsm.defines.YSM_KEY_STORAGE_LOCKED)
         # make sure we can't generate AEADs when keystore is locked
         try:
             res = self.hsm.generate_aead_simple(nonce, 0x2000, cleartext)
             self.fail("Expected YSM_KEY_STORAGE_LOCKED, got %s (before lock: %s)" \
-                          % (res.data.encode('hex'), res_before.data.encode('hex')))
-        except pyhsm.exception.YHSM_CommandFailed, e:
-            self.assertEquals(e.status, pyhsm.defines.YSM_KEY_STORAGE_LOCKED)
+                          % (res.data, res_before.data))
+        except pyhsm.exception.YHSM_CommandFailed as e:
+            self.assertEqual(e.status, pyhsm.defines.YSM_KEY_STORAGE_LOCKED)
         # unlock key store with correct passphrase
-        self.assertTrue(self.hsm.key_storage_unlock(test_common.HsmPassphrase.decode("hex")))
+        self.assertTrue(self.hsm.key_storage_unlock(bytes.fromhex(test_common.HsmPassphrase)))
         # make sure it is properly unlocked
         res_after = self.hsm.generate_aead_simple(nonce, 0x2000, cleartext)
-        self.assertEquals(res_before.data, res_after.data)
+        self.assertEqual(res_before.data, res_after.data)

--- a/test/test_oath.py
+++ b/test/test_oath.py
@@ -6,17 +6,17 @@ import unittest
 import pyhsm
 import pyhsm.oath_hotp
 
-import test_common
+from . import test_common
 
 class TestOath(test_common.YHSM_TestCase):
 
     def setUp(self):
         test_common.YHSM_TestCase.setUp(self)
 
-        key = "3132333435363738393031323334353637383930".decode('hex')
+        key = bytes.fromhex("3132333435363738393031323334353637383930")
 	# Enabled flags 00010000 = YSM_HMAC_SHA1_GENERATE
         flags = struct.pack("< I", 0x10000)
-        self.nonce = 'f1f2f3f4f5f6'.decode('hex')
+        self.nonce = bytes.fromhex('f1f2f3f4f5f6')
         # key 0x2000 has all flags set
         self.key_handle = 0x2000
         self.phantom = pyhsm.defines.YSM_TEMP_KEY_HANDLE
@@ -46,7 +46,7 @@ class TestOath(test_common.YHSM_TestCase):
 
         for c, expected, code in test_vectors:
             hmac_result = self.hsm.hmac_sha1(self.phantom, struct.pack("> Q", c)).get_hash()
-            self.assertEqual(expected, hmac_result.encode('hex'))
+            self.assertEqual(bytes.fromhex(expected), hmac_result)
             self.assertEqual(code, pyhsm.oath_hotp.truncate(hmac_result, length=6))
 
     def test_OATH_HOTP_validation(self):

--- a/test/test_otp_validate.py
+++ b/test/test_otp_validate.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 import pyhsm
 
-import test_common
+from . import test_common
 
 class TestOtpValidate(test_common.YHSM_TestCase):
 
@@ -14,9 +14,9 @@ class TestOtpValidate(test_common.YHSM_TestCase):
 
     def test_load_secret_wrong_key(self):
         """ Test load_secret with key that should not be allowed to. """
-        key = "A" * 16
-        uid = '\x4d\x4d\x4d\x4d\x4d\x4d'
-        public_id = 'f0f1f2f3f4f5'.decode('hex')
+        key = b'AAAAAAAAAAAAAAAA'
+        uid = b'\x4d\x4d\x4d\x4d\x4d\x4d'
+        public_id = bytes.fromhex('f0f1f2f3f4f5')
         # Enabled flags 00000100 = YHSM_AEAD_STORE
         # HSM> < keyload - Load key data now using flags 00000100. Press ESC to quit
         # 00000009 - stored ok
@@ -28,14 +28,14 @@ class TestOtpValidate(test_common.YHSM_TestCase):
         try:
             res = self.hsm.generate_aead(public_id, key_handle)
             self.fail("Expected YSM_FUNCTION_DISABLED, got %s" % (res))
-        except pyhsm.exception.YHSM_CommandFailed, e:
-            self.assertEquals(e.status, pyhsm.defines.YSM_FUNCTION_DISABLED)
+        except pyhsm.exception.YHSM_CommandFailed as e:
+            self.assertEqual(e.status, pyhsm.defines.YSM_FUNCTION_DISABLED)
 
     def test_load_secret(self):
         """ Test load_secret. """
-        key = "A" * 16
-        uid = '\x4d\x01\x4d\x02'
-        public_id = 'f1f2f3f4f5f6'.decode('hex')
+        key = b"A" * 16
+        uid = b'\x4d\x01\x4d\x02'
+        public_id = bytes.fromhex('f1f2f3f4f5f6')
         if self.hsm.version.have_YSM_BUFFER_LOAD():
             # Enabled flags 60000004 = YSM_BUFFER_AEAD_GENERATE,YSM_USER_NONCE,YSM_BUFFER_LOAD
             # HSM (keys changed)> < keyload - Load key data now using flags 60000004. Press ESC to quit
@@ -59,6 +59,6 @@ class TestOtpValidate(test_common.YHSM_TestCase):
 
     def test_yubikey_secrets(self):
         """ Test the class representing the YUBIKEY_SECRETS struct. """
-        aes_128_key = 'a' * 16
-        first = pyhsm.aead_cmd.YHSM_YubiKeySecret(aes_128_key, 'b')
+        aes_128_key = b'aaaaaaaaaaaaaaaa'
+        first = pyhsm.aead_cmd.YHSM_YubiKeySecret(aes_128_key, b'b')
         self.assertEqual(len(first.pack()), pyhsm.defines.KEY_SIZE + pyhsm.defines.UID_SIZE)

--- a/test/test_soft_hsm.py
+++ b/test/test_soft_hsm.py
@@ -5,39 +5,39 @@ import sys
 import unittest
 import pyhsm
 
-import test_common
+from . import test_common
 
 class TestSoftHSM(test_common.YHSM_TestCase):
 
     def setUp(self):
         test_common.YHSM_TestCase.setUp(self)
-        self.nonce = "4d4d4d4d4d4d".decode('hex')
-        self.key = "A" * 16
+        self.nonce = bytes.fromhex("4d4d4d4d4d4d")
+        self.key = b"A" * 16
 
     def test_aes_CCM_encrypt_decrypt(self):
         """ Test decrypting encrypted data. """
-        key = chr(0x09) * 16
+        key = bytes([0x09] * 16)
         key_handle = 1
-        plaintext = "foo".ljust(16, chr(0x0))
+        plaintext = b"foo".ljust(16, b'\x00')
         ct = pyhsm.soft_hsm.aesCCM(key, key_handle, self.nonce, plaintext, decrypt = False)
         pt = pyhsm.soft_hsm.aesCCM(key, key_handle, self.nonce, ct, decrypt = True)
-        self.assertEquals(plaintext, pt)
+        self.assertEqual(plaintext, pt)
 
     def test_aes_CCM_wrong_key(self):
         """ Test decrypting encrypted data with wrong key. """
-        key = chr(0x09) * 16
+        key = bytes([0x09] * 16)
         key_handle = 1
-        plaintext = "foo".ljust(16, chr(0x0))
+        plaintext = b"foo".ljust(16, b'\x00')
         ct = pyhsm.soft_hsm.aesCCM(key, key_handle, self.nonce, plaintext, decrypt = False)
-        key = chr(0x08) * 16
+        key = bytes([0x08] * 16)
         self.assertRaises(pyhsm.exception.YHSM_Error, pyhsm.soft_hsm.aesCCM,
                           key, key_handle, self.nonce, ct, decrypt = True)
 
     def test_aes_CCM_wrong_key_handle(self):
         """ Test decrypting encrypted data with wrong key_handle. """
-        key = chr(0x09) * 16
+        key = bytes([0x09] * 16)
         key_handle = 1
-        plaintext = "foo".ljust(16, chr(0x0))
+        plaintext = b"foo".ljust(16, b'\x00')
         ct = pyhsm.soft_hsm.aesCCM(key, key_handle, self.nonce, plaintext, decrypt = False)
         key_handle = 2
         self.assertRaises(pyhsm.exception.YHSM_Error, pyhsm.soft_hsm.aesCCM,
@@ -46,48 +46,48 @@ class TestSoftHSM(test_common.YHSM_TestCase):
     def test_soft_simple_aead_generation(self):
         """ Test soft_hsm simple AEAD generation. """
         key_handle = 0x2000
-        plaintext = 'foo'.ljust(16, chr(0x0))
-        key = str("2000" * 16).decode('hex')
+        plaintext = b'foo'.ljust(16, b'\x00')
+        key = bytes.fromhex("2000" * 16)
         # generate soft AEAD
         ct = pyhsm.soft_hsm.aesCCM(key, key_handle, self.nonce, plaintext, decrypt = False)
         # generate hard AEAD
         aead = self.hsm.generate_aead_simple(self.nonce, key_handle, plaintext)
 
         ct = pyhsm.soft_hsm.aesCCM(key, key_handle, self.nonce, plaintext, decrypt = False)
-        self.assertEquals(aead.data, ct)
+        self.assertEqual(aead.data, ct)
 
         # decrypt the AEAD again
         pt = pyhsm.soft_hsm.aesCCM(key, key_handle, self.nonce, ct, decrypt = True)
-        self.assertEquals(plaintext, pt)
+        self.assertEqual(plaintext, pt)
 
     def test_soft_generate_long_aead(self):
         """ Test soft_hsm generation of long AEAD. """
         key_handle = 0x2000
-        plaintext = 'A' * 64
-        key = str("2000" * 16).decode('hex')
+        plaintext = b'A' * 64
+        key = bytes.fromhex("2000" * 16)
         # generate soft AEAD
         ct = pyhsm.soft_hsm.aesCCM(key, key_handle, self.nonce, plaintext, decrypt = False)
         # generate hard AEAD
         aead = self.hsm.generate_aead_simple(self.nonce, key_handle, plaintext)
 
-        self.assertEquals(aead.data, ct)
+        self.assertEqual(aead.data, ct)
 
         # decrypt the AEAD again
         pt = pyhsm.soft_hsm.aesCCM(key, key_handle, self.nonce, ct, decrypt = True)
-        self.assertEquals(plaintext, pt)
+        self.assertEqual(plaintext, pt)
 
     def test_soft_generate_yubikey_secrets_aead(self):
         """ Test soft_hsm generation of YubiKey secrets AEAD. """
         key_handle = 0x2000
-        plaintext = 'A' * 22
-        key = str("2000" * 16).decode('hex')
+        plaintext = b'A' * 22
+        key = bytes.fromhex("2000" * 16)
         # generate soft AEAD
         ct = pyhsm.soft_hsm.aesCCM(key, key_handle, self.nonce, plaintext, decrypt = False)
         # generate hard AEAD
         aead = self.hsm.generate_aead_simple(self.nonce, key_handle, plaintext)
 
-        self.assertEquals(aead.data, ct)
+        self.assertEqual(aead.data, ct)
 
         # decrypt the AEAD again
         pt = pyhsm.soft_hsm.aesCCM(key, key_handle, self.nonce, ct, decrypt = True)
-        self.assertEquals(plaintext, pt)
+        self.assertEqual(plaintext, pt)

--- a/test/test_stick.py
+++ b/test/test_stick.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 import pyhsm
 
-import test_common
+from . import test_common
 
 class TestUtil(test_common.YHSM_TestCase):
 
@@ -19,7 +19,7 @@ class TestUtil(test_common.YHSM_TestCase):
 
     def test_debug_output(self):
         """ Test debug output of YubiHSM communication. """
-        self.assertTrue(self.hsm.echo('testing'))
+        self.assertTrue(self.hsm.echo(b'testing'))
         self.assertTrue(self.hsm.drain())
 
     def tearDown(self):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 import pyhsm
 
-import test_common
+from . import test_common
 
 class TestUtil(test_common.YHSM_TestCase):
 
@@ -14,11 +14,11 @@ class TestUtil(test_common.YHSM_TestCase):
 
     def test_hexdump(self):
         """ Test hexdump function. """
-        data1 = ''.join([chr(x) for x in xrange(8)])
-        self.assertEquals('0000   00 01 02 03 04 05 06 07\n', pyhsm.util.hexdump(data1))
-        data2 = ''.join([chr(x) for x in xrange(64)])
-        self.assertEquals(248, len(pyhsm.util.hexdump(data2)))
-        self.assertEquals('', pyhsm.util.hexdump(''))
+        data1 = bytes(range(8))
+        self.assertEqual('0000   00 01 02 03 04 05 06 07\n', pyhsm.util.hexdump(data1))
+        data2 = bytes(range(64))
+        self.assertEqual(248, len(pyhsm.util.hexdump(data2)))
+        self.assertEqual('', pyhsm.util.hexdump(''))
 
     def test_response_validation(self):
         """ Test response validation functions. """
@@ -34,10 +34,10 @@ class TestUtil(test_common.YHSM_TestCase):
                               0, 'foo', exact_len = 5)
 
         self.assertRaises(pyhsm.exception.YHSM_InputTooLong, pyhsm.util.input_validate_str, \
-                              '1234', 'foo', max_len = 3)
-        self.assertEquals('1234', pyhsm.util.input_validate_str('1234', 'foo', max_len = 4))
-        self.assertEquals('1234', pyhsm.util.input_validate_str('1234', 'foo', max_len = 14))
+                              b'1234', 'foo', max_len = 3)
+        self.assertEqual(b'1234', pyhsm.util.input_validate_str(b'1234', 'foo', max_len = 4))
+        self.assertEqual(b'1234', pyhsm.util.input_validate_str(b'1234', 'foo', max_len = 14))
 
         self.assertRaises(pyhsm.exception.YHSM_WrongInputSize, pyhsm.util.input_validate_str, \
-                              '1234', 'foo', exact_len = 5)
-        self.assertEquals('1234', pyhsm.util.input_validate_str('1234', 'foo', exact_len = 4))
+                              b'1234', 'foo', exact_len = 5)
+        self.assertEqual(b'1234', pyhsm.util.input_validate_str(b'1234', 'foo', exact_len = 4))


### PR DESCRIPTION
This is a python-pyhsm package conversion to make it work with python3.

Bumped up dependencies to python3 as well, changed crypto library to pycryptodome, converted the code to python3 standarts, changed the data moving to hsm device from string and other formats to bytes.

Launching tests they do pass successfully (thought sometimes the OTP testing returns OTP_INVALID error, no clue if its a timing thing or something else, but after 2-3 tries it does pass, testing on a installed package OTP works correctly).

Only problems I have is that I have no way to test files in /ksm directory, /val/init_oath_token.py and /tools directory files besides keystore_unlock.py, as I don't have any spare yubikeys to configure a new hsm with (but I don't see why they wouldnt be working, as changes are minimal).

Variable types in methods description are still not changed from string to bytes and some of the code is still a bit messy, but if it's possible to push this change upstream I'll make the changes later.

